### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.4
     - 5.5
     - 5.6
 


### PR DESCRIPTION
Remove php5.4 from test as package  satooshi/php-coveralls will not work due to its min 5.5 support
